### PR TITLE
Update to TorBrowser 12.0.7

### DIFF
--- a/HelperScripts/Install_TorBrowser.cmd
+++ b/HelperScripts/Install_TorBrowser.cmd
@@ -1,8 +1,8 @@
 REM Download Tor Browser
-curl -L "https://www.torproject.org/dist/torbrowser/12.0.4/torbrowser-install-win64-12.0.4_ALL.exe" --output C:\users\WDAGUtilityAccount\Downloads\torbrowser-install-win64-12.0.4_ALL.exe
+curl -L "https://www.torproject.org/dist/torbrowser/12.0.7/torbrowser-install-win64-12.0.7_ALL.exe" --output C:\users\WDAGUtilityAccount\Downloads\torbrowser-install-win64-12.0.7_ALL.exe
 
 REM Install and run Tor Browser
-START /B /WAIT C:\users\WDAGUtilityAccount\Downloads\torbrowser-install-win64-12.0.4_ALL.exe /S /D=C:\users\WDAGUtilityAccount\Desktop
+START /B /WAIT C:\users\WDAGUtilityAccount\Downloads\torbrowser-install-win64-12.0.7_ALL.exe /S /D=C:\users\WDAGUtilityAccount\Desktop
 IF %ERRORLEVEL% == 0 (
     START /B C:\users\WDAGUtilityAccount\Desktop\Browser\firefox.exe
 )


### PR DESCRIPTION
Replaced download URI, output path and call path to TorBrowser 12.0.7. Fixes #1 